### PR TITLE
Restyle landing page and template firmware list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,17 +20,10 @@ jobs:
     outputs:
       firmwares: ${{ steps.config.outputs.firmwares }}
     steps:
+      - name: Checkout this repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - id: config
-        run: |
-          FIRMWARES=$(jq -c . <<'EOF'
-          [
-            {"name": "Official",    "repo": "flipperdevices/flipperzero-firmware",      "channel": "dev"},
-            {"name": "Unleashed",   "repo": "DarkFlippers/unleashed-firmware",          "channel": "Unleashed"},
-            {"name": "RogueMaster", "repo": "RogueMaster/flipperzero-firmware-wPlugins","channel": "RogueMaster"}
-          ]
-          EOF
-          )
-          echo "firmwares=$FIRMWARES" >> $GITHUB_OUTPUT
+        run: echo "firmwares=$(jq -c . firmwares.json)" >> $GITHUB_OUTPUT
 
   build:
     name: Build ${{ matrix.firmware.name }} Firmware

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,18 +14,31 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  setup:
+    name: Configure firmwares
+    runs-on: ubuntu-latest
+    outputs:
+      firmwares: ${{ steps.config.outputs.firmwares }}
+    steps:
+      - id: config
+        run: |
+          FIRMWARES=$(jq -c . <<'EOF'
+          [
+            {"name": "Official",    "repo": "flipperdevices/flipperzero-firmware",      "channel": "dev"},
+            {"name": "Unleashed",   "repo": "DarkFlippers/unleashed-firmware",          "channel": "Unleashed"},
+            {"name": "RogueMaster", "repo": "RogueMaster/flipperzero-firmware-wPlugins","channel": "RogueMaster"}
+          ]
+          EOF
+          )
+          echo "firmwares=$FIRMWARES" >> $GITHUB_OUTPUT
+
   build:
     name: Build ${{ matrix.firmware.name }} Firmware
+    needs: setup
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        firmware:
-          - name: Official
-            repo: flipperdevices/flipperzero-firmware
-          - name: Unleashed
-            repo: DarkFlippers/unleashed-firmware
-          - name: RogueMaster
-            repo: RogueMaster/flipperzero-firmware-wPlugins
+        firmware: ${{ fromJSON(needs.setup.outputs.firmwares) }}
       fail-fast: false
     steps:
       - name: Checkout this repo
@@ -57,7 +70,7 @@ jobs:
 
   consolidate:
     name: Consolidate firmwares
-    needs: build
+    needs: [setup, build]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repo
@@ -70,21 +83,24 @@ jobs:
         run: |
           mkdir output
           cp -R firmwares/*/* output/
-      - name: Get template variables
+      - name: Build template inputs
         id: variables
+        env:
+          FIRMWARES_INPUT: ${{ needs.setup.outputs.firmwares }}
         run: |
-          OfficialFilename=$(ls output/Official-*.tgz | cut -f2 -d'/')
-          UnleashedFilename=$(ls output/Unleashed-*.tgz | cut -f2 -d'/')
-          RogueMasterFilename=$(ls output/RogueMaster-*.tgz | cut -f2 -d'/')
+          ENRICHED='[]'
+          while IFS= read -r row; do
+            name=$(echo "$row" | jq -r '.name')
+            filename=$(ls output/${name}-*.tgz | head -n1 | cut -f2 -d'/')
+            version=$(echo "$filename" | cut -f1 -d'.' | cut -d'-' -f2-4)
+            ENRICHED=$(echo "$ENRICHED" | jq -c \
+              --argjson item "$row" \
+              --arg fn "$filename" \
+              --arg ver "$version" \
+              '. + [{Name: $item.name, Repo: $item.repo, Channel: $item.channel, Filename: $fn, Version: $ver}]')
+          done < <(echo "$FIRMWARES_INPUT" | jq -c '.[]')
 
-          echo "OfficialFilename=$OfficialFilename" >> $GITHUB_OUTPUT
-          echo "UnleashedFilename=$UnleashedFilename" >> $GITHUB_OUTPUT
-          echo "RogueMasterFilename=$RogueMasterFilename" >> $GITHUB_OUTPUT
-
-          echo "OfficialVersion=$(echo "$OfficialFilename" | cut -f1 -d'.' | cut -d'-' -f2-4)" >> $GITHUB_OUTPUT
-          echo "UnleashedVersion=$(echo "$UnleashedFilename" | cut -f1 -d'.' | cut -d'-' -f2-4)" >> $GITHUB_OUTPUT
-          echo "RogueMasterVersion=$(echo "$RogueMasterFilename" | cut -f1 -d'.' | cut -d'-' -f2-4)" >> $GITHUB_OUTPUT
-
+          echo "Firmwares=$ENRICHED" >> $GITHUB_OUTPUT
           echo "Timestamp=$(date '+%Y-%m-%d %H:%M %Z')" >> $GITHUB_OUTPUT
 
       - uses: badsyntax/github-action-render-template@710c485d6c34904bb78f891c078103015584203d # v1.0.1
@@ -94,15 +110,7 @@ jobs:
           template: "static/index.html.hbs"
           inputs: |
             {
-              "OfficialFilename": "${{ steps.variables.outputs.OfficialFilename }}",
-              "OfficialVersion": "${{ steps.variables.outputs.OfficialVersion }}",
-
-              "UnleashedFilename": "${{ steps.variables.outputs.UnleashedFilename }}",
-              "UnleashedVersion": "${{ steps.variables.outputs.UnleashedVersion }}",
-
-              "RogueMasterFilename": "${{ steps.variables.outputs.RogueMasterFilename }}",
-              "RogueMasterVersion": "${{ steps.variables.outputs.RogueMasterVersion }}",
-
+              "Firmwares": ${{ steps.variables.outputs.Firmwares }},
               "Timestamp": "${{ steps.variables.outputs.Timestamp }}"
             }
 

--- a/firmwares.json
+++ b/firmwares.json
@@ -1,0 +1,17 @@
+[
+  {
+    "name": "Official",
+    "repo": "flipperdevices/flipperzero-firmware",
+    "channel": "dev"
+  },
+  {
+    "name": "Unleashed",
+    "repo": "DarkFlippers/unleashed-firmware",
+    "channel": "Unleashed"
+  },
+  {
+    "name": "RogueMaster",
+    "repo": "RogueMaster/flipperzero-firmware-wPlugins",
+    "channel": "RogueMaster"
+  }
+]

--- a/static/index.html.hbs
+++ b/static/index.html.hbs
@@ -1,50 +1,173 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
 
 <head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Flipper Zero Firmware Builds</title>
+    <style>
+        :root {
+            color-scheme: light dark;
+            --bg: #f7f7f8;
+            --fg: #1a1a1a;
+            --card: #ffffff;
+            --muted: #6b7280;
+            --border: #e5e7eb;
+            --accent: #ff8200;
+        }
+
+        @media (prefers-color-scheme: dark) {
+            :root {
+                --bg: #111214;
+                --fg: #f3f4f6;
+                --card: #1c1d21;
+                --muted: #9ca3af;
+                --border: #2a2b30;
+            }
+        }
+
+        * { box-sizing: border-box; }
+
+        body {
+            margin: 0;
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            background: var(--bg);
+            color: var(--fg);
+            line-height: 1.5;
+        }
+
+        main {
+            max-width: 720px;
+            margin: 0 auto;
+            padding: 2.5rem 1.25rem 4rem;
+        }
+
+        header {
+            margin-bottom: 2rem;
+        }
+
+        h1 {
+            margin: 0 0 0.5rem;
+            font-size: 2rem;
+        }
+
+        .lede {
+            color: var(--muted);
+            margin: 0;
+        }
+
+        .meta {
+            color: var(--muted);
+            font-size: 0.9rem;
+            margin-top: 0.75rem;
+        }
+
+        .meta a {
+            color: var(--muted);
+            text-decoration: underline;
+        }
+
+        .firmwares {
+            display: grid;
+            gap: 1rem;
+        }
+
+        .firmware {
+            background: var(--card);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 1.25rem 1.5rem;
+            display: grid;
+            grid-template-columns: 1fr auto;
+            align-items: center;
+            gap: 0.25rem 1rem;
+        }
+
+        .firmware h2 {
+            margin: 0;
+            font-size: 1.25rem;
+            color: var(--fg);
+        }
+
+        .firmware .version {
+            color: var(--muted);
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            font-size: 0.9rem;
+            margin-left: 0.5rem;
+        }
+
+        .firmware .repo {
+            grid-column: 1;
+            font-size: 0.9rem;
+            color: var(--muted);
+        }
+
+        .firmware .repo a {
+            color: var(--muted);
+        }
+
+        .install {
+            grid-column: 2;
+            grid-row: 1 / span 2;
+            align-self: center;
+            display: inline-block;
+            background: var(--accent);
+            color: #1a1a1a;
+            font-weight: 600;
+            font-size: 0.9rem;
+            text-decoration: none;
+            padding: 0.55rem 1rem;
+            border-radius: 8px;
+            white-space: nowrap;
+            transition: filter 0.15s ease;
+        }
+
+        .install:hover {
+            filter: brightness(1.05);
+        }
+    </style>
 </head>
 
 <body>
-    <h1>Flipper Zero Firmware Builds</h1>
+    <main>
+        <header>
+            <h1>Flipper Zero Firmware Builds</h1>
+            <p class="lede">Daily firmware builds for the Flipper Zero, ready to flash via <a href="https://lab.flipper.net/" target="_blank" rel="noopener">lab.flipper.net</a>.</p>
+            <p class="meta">
+                Last build: <span id="timestamp">{{Timestamp}}</span>
+                &middot;
+                <a href="https://github.com/jesserockz/flipperzero-firmware-builds" target="_blank" rel="noopener">View this repo on GitHub</a>
+            </p>
+        </header>
 
-    <p>This repository contains daily firmware builds for Flipper Zero.</p>
-
-    <p>Last build time: <span id="timestamp">{{Timestamp}}</span></p>
-
-    <h2><a target="_blank"
-            href="https://lab.flipper.net/?url=https://jesserockz.github.io/flipperzero-firmware-builds/{{OfficialFilename}}&channel=dev&version={{OfficialVersion}}">Official</a>
-        - {{OfficialVersion}}
-        - <a href="https://github.com/flipperdevices/flipperzero-firmware">Repo</a>
-    </h2>
-
-    <h2><a target="_blank"
-            href="https://lab.flipper.net/?url=https://jesserockz.github.io/flipperzero-firmware-builds/{{UnleashedFilename}}&channel=Unleashed&version={{UnleashedVersion}}">Unleashed</a>
-        - {{UnleashedVersion}}
-        - <a href="https://github.com/DarkFlippers/unleashed-firmware">Repo</a>
-    </h2>
-
-    <h2><a target="_blank"
-            href="https://lab.flipper.net/?url=https://jesserockz.github.io/flipperzero-firmware-builds/{{RogueMasterFilename}}&channel=RogueMaster&version={{RogueMasterVersion}}">RogueMaster</a>
-        - {{RogueMasterVersion}}
-        - <a href="https://github.com/RogueMaster/flipperzero-firmware-wPlugins">Repo</a>
-    </h2>
+        <section class="firmwares">
+            {{#each Firmwares}}
+            <article class="firmware">
+                <h2>{{Name}}<span class="version">{{Version}}</span></h2>
+                <span class="repo"><a href="https://github.com/{{Repo}}" target="_blank" rel="noopener">{{Repo}}</a></span>
+                <a class="install" target="_blank" rel="noopener"
+                    href="https://lab.flipper.net/?url=https://jesserockz.github.io/flipperzero-firmware-builds/{{Filename}}&channel={{Channel}}&version={{Version}}">Install</a>
+            </article>
+            {{/each}}
+        </section>
+    </main>
 
     <script type="text/javascript">
         var timestamp = document.getElementById('timestamp'),
             t         = new Date(timestamp.innerHTML),
-            hours     = t.getHours(), 
-            min       = t.getMinutes() + '', 
+            hours     = t.getHours(),
+            min       = t.getMinutes() + '',
             pm        = false,
             months    = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
-    
-        if(hours > 11){
-           hours = hours - 12;
-           pm = true;
+
+        if (hours > 11) {
+            hours = hours - 12;
+            pm = true;
         }
-    
-        if(hours == 0) hours = 12;
-        if(min.length == 1) min = '0' + min;
-    
+
+        if (hours == 0) hours = 12;
+        if (min.length == 1) min = '0' + min;
+
         timestamp.innerHTML = months[t.getMonth()] + ' ' + t.getDate() + ', ' + t.getFullYear() + ' ' + hours + ':' + min + ' ' + (pm ? 'pm' : 'am');
     </script>
 </body>


### PR DESCRIPTION
## Summary

- Restyle the GitHub Pages landing page: card layout, dark-mode support, per-firmware **Install** button, and a link back to this repository.
- Move the firmware list to a top-level [`firmwares.json`](firmwares.json). The workflow's new `setup` job loads it and exposes it as a job output, so the build matrix and the rendered template both consume the same source of truth.
- Page now renders any number of firmwares via a Handlebars `{{#each Firmwares}}` loop.

## Why

Adding or removing a firmware previously required editing three places (matrix, consolidate step, template). Now it's one entry in `firmwares.json`.

## Test plan

- [ ] CI builds Official, Unleashed, and RogueMaster as before.
- [ ] `consolidate` job renders `index.html` with three cards, each linking via `lab.flipper.net` and showing the source repo.
- [ ] Page deploys to GitHub Pages and renders correctly in light + dark mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)