### PR TITLE
Cache firmware builds with ccache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,11 @@ jobs:
         with:
           repository: ${{ matrix.firmware.repo }}
           path: firmware
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@d62db5f07c26379fc4b4e0916f098a92573c3b03 # v1.2.23
+        with:
+          key: ${{ matrix.firmware.name }}
+          max-size: 500M
       - name: Build firmware
         id: build
         working-directory: firmware


### PR DESCRIPTION
## Summary

- Adds `hendrikmuhs/ccache-action` (pinned to v1.2.23 SHA) before each firmware build step.
- fbt auto-detects ccache via `scripts/fbt_tools/ccache.py` and prefixes `CC` / `CXX` with it — no further config needed.
- Per-fork cache key (`Official` / `Unleashed` / `RogueMaster`) so the three forks don't share cache entries; `max-size: 500M` keeps each under GH Actions' 10 GB per-repo cap.

## Why

Wall-clock for the workflow is dominated by RogueMaster's ~10 minute compile. The ARM toolchain bootstrap is only ~10s so caching it would be wasted; ccache targets the actual bottleneck (compilation) and should give meaningful speedups on subsequent runs where most files are unchanged upstream.

## Test plan

- [ ] First run after merge populates caches (no speedup expected).
- [ ] Subsequent scheduled run shows reduced "Build firmware" duration, especially on RogueMaster.
- [ ] Confirm ccache stats in build log (action prints them at end of step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)