### PR TITLE
Add Momentum to firmware builds

### DIFF
--- a/firmwares.json
+++ b/firmwares.json
@@ -13,5 +13,10 @@
     "name": "RogueMaster",
     "repo": "RogueMaster/flipperzero-firmware-wPlugins",
     "channel": "RogueMaster"
+  },
+  {
+    "name": "Momentum",
+    "repo": "Next-Flip/Momentum-Firmware",
+    "channel": "Momentum"
   }
 ]


### PR DESCRIPTION
## Summary
- Adds [Next-Flip/Momentum-Firmware](https://github.com/Next-Flip/Momentum-Firmware) to the daily firmware build matrix.
- Momentum is the actively-maintained successor to the archived Xtreme firmware and the largest popular Flipper Zero firmware not yet covered (~8.4k stars, recent commits).
- Uses the standard `./fbt updater_package` flow, so the existing build/consolidate/deploy workflow handles it without changes.

## Test plan
- [ ] Workflow run produces a `Momentum-*.tgz` artifact alongside the existing firmwares.
- [ ] Rendered `index.html` includes a Momentum entry with a working `lab.flipper.net` install link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)